### PR TITLE
updated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
   "homepage": "https://github.com/fuyaode/react-native-app-intro#readme",
   "dependencies": {
     "assign-deep": "^0.4.5",
-    "react-native-swiper": "git+https://github.com/FuYaoDe/react-native-swiper.git"
-  },
-  "peerDependencies": {
+    "react-native-swiper": "git+https://github.com/FuYaoDe/react-native-swiper.git",
     "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
When prop-types is left in peerDependencies, it is always flagged and not installed. Adding it to dependencies solved this.

Kindly merge this before your branched merged to the FuYaoDe:master